### PR TITLE
Fix bug in post copy timestamp

### DIFF
--- a/packages/blog/app/controllers/blog/posts_controller.rb
+++ b/packages/blog/app/controllers/blog/posts_controller.rb
@@ -64,7 +64,7 @@ module Blog
 
     def dup
       @new_post = @post.dup
-      @new_post.title = @new_post.title + " (copy)(#{Time.now.strftime('%Y-%m-%d %H:%H:%S')})"
+      @new_post.title = @new_post.title + " (copy)(#{Time.now.strftime('%Y-%m-%d %H:%M:%S')})"
 
       respond_to do |format|
         if @new_post.save


### PR DESCRIPTION
## Summary
- fix a typo in the timestamp format when duplicating a post

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6871af5daf308329993de8eebde35d7b